### PR TITLE
feat(valkey-bundle): mirror valkey-bundle 9.1.1 for ReJSON consumers (PLT-3241)

### DIFF
--- a/valkey-bundle/Dockerfile
+++ b/valkey-bundle/Dockerfile
@@ -1,0 +1,1 @@
+FROM valkey/valkey-bundle:9.1.1


### PR DESCRIPTION
## What

Adds `valkey-bundle/Dockerfile` pinned to `valkey/valkey-bundle:9.1.1`, mirroring it to `ghcr.io/userlane/tool-external-images/valkey-bundle:9.1.1`.

## Why

Part of [PLT-3241](https://userlanerds.atlassian.net/browse/PLT-3241), the migration off the frozen Bitnami redis catalogue.

`service-tutorial-step-screenshots` (and `service-translation-io`, which shares its Redis instance) store JSON documents through RedisJSON 1.0.8. Today that module is fetched at pod start by an init container running `wget https://s3.amazonaws.com/redismodules/rejson/rejson.Linux-x86_64.1.0.8.zip`, an unauthenticated runtime dependency on a third-party URL.

Plain Valkey has no JSON module, so those two consumers are the only ones on the ticket that cannot migrate on the already-mirrored `valkey` image.

`valkey-bundle` ships `valkey-json` preloaded. It registers its data type as `ReJSON-RL` specifically for RDB compatibility with RedisJSON, and is compatible with RedisJSON 1.0.8 and later (up to ReJSON 2.6.12). The deployed version is exactly 1.0.8, so the existing dataset can replicate across instead of being rebuilt.

## Notes

- Same `9.1.1` appVersion as the existing `valkey` mirror, so the two move together.
- The build workflow triggers on push to any branch, so the image is published from this branch before merge. Merging keeps it reproducible from `master`.
- Command-level behaviour of `valkey-json` against how these two services actually use JSON commands is still to be verified in a `testN` environment. That check is tracked on PLT-3241, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PLT-3241]: https://userlanerds.atlassian.net/browse/PLT-3241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ